### PR TITLE
audio node creation optimization

### DIFF
--- a/demos/nakayoshi sensation.json
+++ b/demos/nakayoshi sensation.json
@@ -2,7 +2,7 @@
     "measures": 50,
     "tempo": 156,
     "composer": "大久保 薫",
-    "title": "なかよしセンセーション",
+    "title": "なかよしセンセーション (Princess Connect! Re:Dive)",
     "timeSignature": "4/4",
     "subdivision": 8,
     "instruments": [

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 		<li><button id='play' class='btn'> play! </button></li>
 		<li><button id='playAll' class='btn'> play <b>all</b>! </button></li>
 		<li><button id='stopPlay' class='btn'> stop! </button></li>
-		<li><button id='loop' class='btn'>loop</button></li>
+		<!--<li><button id='loop' class='btn'>loop</button></li>-->
 		<li><button id='record' class='btn'> record </button></li>
 		<li><button id='addMeasure' class='btn'> add new measure </button></li>
 		

--- a/main.js
+++ b/main.js
@@ -158,6 +158,7 @@ function bindButtons(pianoRollObject){
 		name.textContent = userInput;
 	});
 	
+	/*
 	document.getElementById('loop').addEventListener('click', function(){
 		pianoRoll.loopFlag = !pianoRoll.loopFlag;
 		if(pianoRoll.loopFlag){
@@ -165,7 +166,7 @@ function bindButtons(pianoRollObject){
 		}else{
 			this.style.border = "";
 		}
-	});
+	});*/
 	
 	// toggle time signature 
 	document.getElementById('timeSig').addEventListener('change', function(){

--- a/src/classes.js
+++ b/src/classes.js
@@ -173,7 +173,7 @@ function PianoRoll(){
 	this.audioContextDestOriginal; // the original audio context destination 
 	this.audioContextDestMediaStream; // a media stream destination for the audio context (to be used when recording is desired)
 	this.audioDataChunks = [];
-	this.lastTime; 				// the time the last note was supposed to be played
+	this.lastTime = 0; 			// the time the last note was supposed to be played
 	this.isPlaying = false;		// a boolean flag to easily quit playing
 	this.loopFlag = false;		// if playback should be looped or not 
 	this.recording = false;		// if recording. note that if looping, recording should not be possible.

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -453,6 +453,7 @@ function scheduler(pianoRoll, allInstruments){
 			posTracker[instrumentIndex][i] = 0;
 		}
 		
+		// use instrumentNotePointers to take into account the startMarker 
 		var start = instrumentNotePointers[instrumentIndex];
 		for(var index = start; index < instrument.notes.length; index++){
 			var group = instrument.notes[index];
@@ -564,8 +565,8 @@ function scheduler(pianoRoll, allInstruments){
 					startTimeOffset = timeOffsetAcc + timeDiff;
 				}
 				
-				console.log("time offset: " + timeOffsetAcc);
-				timeOffsetAcc += startTimeOffset;
+				//console.log("time offset: " + timeOffsetAcc);
+				timeOffsetAcc = startTimeOffset;
 				
 				var noteSetup = {
 					"note": thisNote,
@@ -589,9 +590,8 @@ function scheduler(pianoRoll, allInstruments){
 	for(var i = 0; i < instruments.length; i++){
 		
 		var currInstNotes = allNotesPerInstrument[i];
-		var numNotesLeft = currInstNotes.length - instrumentNotePointers[i];
+		//var numNotesLeft = currInstNotes.length - instrumentNotePointers[i];
 		
-
 		currInstNotes.forEach((note) => {
 			
 			// schedule the notes!
@@ -629,7 +629,7 @@ function scheduler(pianoRoll, allInstruments){
 			gain.gain.setTargetAtTime(0.0, (thisTime + startTimeOffset + duration - .0025), 0.0010);
 			
 			// increment the note pointer for this instrument 
-			instrumentNotePointers[i]++;
+			//instrumentNotePointers[i]++;
 		});
 		
 	}

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -127,7 +127,6 @@ function sortNotesByPosition(instrument){
 	// organize notes by position
 	var positionMapping = {};
 	for(var noteId in instrument.activeNotes){
-		
 		var note = instrument.activeNotes[noteId];
 		
 		if(note.style.left === ""){
@@ -160,7 +159,6 @@ function readInNotes(instrument, pianoRollObject){
 
 	var notePositions = Object.keys(notePosMap).sort(function(a, b){ return a - b });
 	notePositions.forEach(function(position){
-		
 		var notes = notePosMap[position]; // a list of at least 1 note
 			
 		// single note or not, just put them all in lists so it'll be easier to process in the scheduler
@@ -174,7 +172,6 @@ function readInNotes(instrument, pianoRollObject){
 		});
 		
 		allNotes.push(group);
-		
 	});
 	
 	// update active notes
@@ -330,15 +327,13 @@ function scheduler(pianoRoll, allInstruments){
 		//console.log(instrument.notes);
 		var prevNote = null;
 		var currNote = null;
-
 		var start = instrumentNotePointers[instIndex];
-		//console.log(start);
+
 		for(var index = start; index < instrument.notes.length; index++){
 			
 			var group = instrument.notes[index];			
 
 			if(index > start){
-				
 				// find the longest note in the prev group
 				if(!prevNote){
 					prevNote = document.getElementById(instrument.notes[index-1][0].block.id);
@@ -358,9 +353,7 @@ function scheduler(pianoRoll, allInstruments){
 						longestCurrNote = n;
 					}
 				});
-				
-				//console.log("longest curr note: " + longestCurrNote.id);
-				//console.log("longest prev note: " + prevNote.id);
+
 				currNote = longestCurrNote;
 				
 				var prevNotePos = getNotePosition(prevNote);
@@ -368,7 +361,6 @@ function scheduler(pianoRoll, allInstruments){
 				var currNotePos = getNotePosition(currNote);
 				
 				if(currNotePos < (prevNotePos + prevNoteLen)){
-					//console.log("currNotePos: " + currNotePos + ", prevNote: " + (prevNotePos + prevNoteLen));
 					if(!numGainNodePerInst[instIndex]){
 						numGainNodePerInst[instIndex] = 2;
 					}else{
@@ -414,7 +406,6 @@ function scheduler(pianoRoll, allInstruments){
 		}
 	}
 	
-
 	// 'route' the notes i.e. assign them to the gain/osc nodes such that they all get played properly
 	var routes = {}; // map instrument to another map of gain nodes to the notes that should be played by those nodes
 	var posTracker = {};
@@ -432,19 +423,18 @@ function scheduler(pianoRoll, allInstruments){
 		// use instrumentNotePointers to take into account the startMarker 
 		var start = instrumentNotePointers[instrumentIndex];
 		for(var index = start; index < instrument.notes.length; index++){
+			
 			var group = instrument.notes[index];
+			
 			group.forEach((note, noteIndex) => {
-				
 				var lastEndPositions = posTracker[instrumentIndex]; // this is a map!
-
 				var n = document.getElementById(note.block.id);
 				var endPosCurrNote = getNotePosition(n) + parseInt(n.style.width);
 				var startPosCurrNote = getNotePosition(n);
 				var gainNodeRoutes = instrumentGainNodes[instrumentIndex];
 				
-				// try the first gain node in the map to see if they can handle this note. i.e. if another note should be playing for this gain 
-				// while this current note is supposed to start, this gain node cannot support this current note.
-				// if not, keep going down the list
+				// try each gain node in the map to see if they can handle this note. i.e. if another note should be playing for this gain 
+				// while this current note is supposed to start, then this gain node cannot support this current note.
 				// there should always be a possible gain node route option available
 				for(var i = 0; i < gainNodeRoutes.length; i++){
 					if(lastEndPositions[i] <= startPosCurrNote){
@@ -454,12 +444,11 @@ function scheduler(pianoRoll, allInstruments){
 						break;
 					}
 				}
-					
 			});
 		}
 	});
 
-	// start up the oscillators vrrrmmmmmmmm
+	// start up the oscillators vrrroooooommmmmmmm
 	for(var inst in instrumentOscNodes){
 		instrumentOscNodes[inst].forEach((osc) => {
 			osc.start();
@@ -478,16 +467,12 @@ function scheduler(pianoRoll, allInstruments){
 		allNotesPerInstrument[instrument] = [];
 		
 		var instrumentRoutes = routes[instrument];
-		//console.log(instrumentRoutes);
 		var currInstGainNodes = instrumentGainNodes[index];
 		var currInstOscNodes = instrumentOscNodes[index];
-		//console.log(currInstGainNodes);
 		
 		// for each gain node, hook to right dest 
 		var gainIndex = 0;
 		for(var route in instrumentRoutes){
-			//console.log(route);
-			console.log(instrumentRoutes[route]);
 			var notes = instrumentRoutes[route];
 			var gainToUse = currInstGainNodes[gainIndex];
 			var oscToUse = currInstOscNodes[gainIndex];
@@ -501,7 +486,6 @@ function scheduler(pianoRoll, allInstruments){
 			var timeOffsetAcc = 0; // time offset accumulator so we know when notes need to start relative to the beginning of the start of playing
 			for(var i = 0; i < notes.length; i++){
 				var thisNote = notes[i]; 
-				
 				var volume = thisNote.freq > 0.0 ? parseFloat(thisNote.block.volume) : 0.0;
 				
 				// by default, ~70% of the note duration should be played 
@@ -517,7 +501,6 @@ function scheduler(pianoRoll, allInstruments){
 				
 				var startTimeOffset = 0;
 				if(i === 0){
-					// for the very first note
 					// the first note on the piano roll might not start at the beginning (i.e. there might be an initial rest)
 					// so let's account for that here 
 					// if startMarker is specified, we can use its position to figure out the initial rest
@@ -536,8 +519,7 @@ function scheduler(pianoRoll, allInstruments){
 					var timeDiff = getCorrectLength(thisNotePos - prevNotePos, pianoRoll) / 1000;
 					startTimeOffset = timeOffsetAcc + timeDiff;
 				}
-				
-				//console.log("time offset: " + timeOffsetAcc);
+
 				timeOffsetAcc = startTimeOffset;
 				
 				var noteSetup = {
@@ -548,7 +530,6 @@ function scheduler(pianoRoll, allInstruments){
 					"volume": volume,
 					"startTimeOffset": startTimeOffset
 				}
-				
 				allNotesPerInstrument[instrument].push(noteSetup);
 			}
 			gainIndex++;
@@ -556,37 +537,12 @@ function scheduler(pianoRoll, allInstruments){
 		index++;
 	}
 	
-
 	var thisTime = ctx.currentTime;
 	for(var i = 0; i < instruments.length; i++){
 		
 		var currInstNotes = allNotesPerInstrument[i];
 		
 		currInstNotes.forEach((note) => {
-			
-			/*
-				NEED TO HANDLE DIFF INSTRUMENTS 
-			
-			if(instruments[i].waveType === "percussion"){
-			
-				// find out what octave the note is in
-				var noteContainer = document.getElementById(thisNote.block.id).parentNode;
-				var octave = parseInt(noteContainer.id.match(/[0-9]/g)[0]);
-
-				if(octave >= 2 && octave <= 4){
-					osc = pianoRoll.PercussionManager.kickDrumNote(thisNote.freq, volume, nextTime[i], true);
-				}else if(octave === 5){
-					osc = pianoRoll.PercussionManager.snareDrumNote(thisNote.freq, volume, nextTime[i], true);
-				}else{
-					osc = pianoRoll.PercussionManager.hihatNote(volume, nextTime[i], true);
-				}
-			}else if(pianoRoll.instrumentPresets[instruments[i].waveType]){
-				// custom intrument preset!
-				var currPreset = pianoRoll.instrumentPresets[instruments[i].waveType];
-				var instrumentPresetNodes = processNote(thisNote.freq, volume, nextTime[i], pianoRoll, currPreset); 
-			}
-					
-			*/
 			
 			// schedule the notes!
 			var osc = note.osc;
@@ -595,41 +551,66 @@ function scheduler(pianoRoll, allInstruments){
 			var volume = note.volume;
 			var startTimeOffset = note.startTimeOffset;
 			var otherParams = note.note;
+			pianoRoll.lastTime = Math.max(pianoRoll.lastTime, (thisTime + startTimeOffset));
 			
-			osc.type = instruments[i].waveType;
-			
-			if(otherParams.freq < 440){
-				// need to set initial freq to 0 for low notes (C3 and below)
-				// otherwise gliding will be messed up for notes on one end of the spectrum
-				osc.frequency.setValueAtTime(0.0, 0.0);
-			}
-
-			//console.log(otherParams.block.id + " starting at: " + (thisTime + startTimeOffset));
-
-			if(otherParams.block.style === "glide"){
-				osc.frequency.setTargetAtTime(otherParams.freq, thisTime + startTimeOffset, 0.025);
+			if(instruments[i].waveType === "percussion"){
+				// hmm gotta make a new osc for every percussion note? need to explore this some more.
+				var noteContainer = document.getElementById(otherParams.block.id).parentNode;
+				var octave = parseInt(noteContainer.id.match(/[0-9]/g)[0]);
+				var oscList;
+				
+				if(octave >= 2 && octave <= 4){
+					oscList = pianoRoll.PercussionManager.kickDrumNote(otherParams.freq, volume, thisTime + startTimeOffset, true);
+				}else if(octave === 5){
+					oscList = pianoRoll.PercussionManager.snareDrumNote(otherParams.freq, volume, thisTime + startTimeOffset, true);
+				}else{
+					oscList = pianoRoll.PercussionManager.hihatNote(volume, thisTime + startTimeOffset, true);
+				}
+				
+				oscList.forEach((osc) => {
+					pianoRoll.timers.push(osc);
+					osc.start(thisTime + startTimeOffset);
+					osc.stop(thisTime + startTimeOffset + duration);
+				});
+				
+			}else if(pianoRoll.instrumentPresets[instruments[i].waveType]){
+				// TODO
+				//var currPreset = pianoRoll.instrumentPresets[instruments[i].waveType];
+				//var instrumentPresetNodes = processNote(thisNote.freq, volume, nextTime[i], pianoRoll, currPreset); 
 			}else{
-				osc.frequency.setValueAtTime(otherParams.freq, thisTime + startTimeOffset);
-			}
 			
+				osc.type = instruments[i].waveType;
 			
-			// setting gain value here depending on condition allows for the 'articulation' of notes without 
-			// the 'helicopter' sound when a certain note frequency is 0 but gain is not 0.
-			// this is fixed by always setting gain to 0 if a note's frequency is 0.
-			gain.gain.setTargetAtTime(volume, thisTime + startTimeOffset, 0.0045); 
-			
-			// change gain to 0 after a really small amount of time to give the impression of articulation
-			gain.gain.setTargetAtTime(0.0, (thisTime + startTimeOffset + duration - .0025), 0.0010);
+				if(otherParams.freq < 440){
+					// need to set initial freq to 0 for low notes (C3 and below)
+					// otherwise gliding will be messed up for notes on one end of the spectrum
+					osc.frequency.setValueAtTime(0.0, 0.0);
+				}
 
+				if(otherParams.block.style === "glide"){
+					osc.frequency.setTargetAtTime(otherParams.freq, thisTime + startTimeOffset, 0.025);
+				}else{
+					osc.frequency.setValueAtTime(otherParams.freq, thisTime + startTimeOffset);
+				}
+				
+				// setting gain value here depending on condition allows for the 'articulation' of notes without 
+				// the 'helicopter' sound when a certain note frequency is 0 but gain is not 0.
+				// this is fixed by always setting gain to 0 if a note's frequency is 0.
+				gain.gain.setTargetAtTime(volume, thisTime + startTimeOffset, 0.0045); 
+				
+				// cut the duration by just a little bit to give the impression of articulation
+				gain.gain.setTargetAtTime(0.0, (thisTime + startTimeOffset + duration - .0025), 0.0010);
+				osc.frequency.setValueAtTime(0.0, (thisTime + startTimeOffset + duration));
+			}
 		});
 	}
 
-	
+	/*
 	if(pianoRoll.loopFlag && pianoRoll.isPlaying){
 		// is this actually correct? the last oscillator in timers might not be necessarily the last note of the piece?
 		// seems to work well most, if not all the time though so far.
 		pianoRoll.timers[pianoRoll.timers.length-1].onended = function(){loopSignal(pianoRoll, allInstruments)};
-	}
+	}*/
 	
 }
 

--- a/todo.txt
+++ b/todo.txt
@@ -4,7 +4,14 @@
   otherwise, performance on Firefox seems to have improved considerably from at least a year ago for my application.
   
 - onion-skin sometimes prevents resizing ability? (can't reproduce currrently :/)
-  
+- looping implementation was questionable and removed for now
+
+- looks like reducing the number of audio nodes helps performance in terms of less latency (yay!) but I think since we reuse nodes and don't
+  call stop on them for each note like we previously did, this doesn't quite make scheduling as on-point as it previously was (boooo!) and could
+  introduce a bit more lag time in the scheduling. not sure if having better scheduling is more favorable to have than latency due to number of nodes.
+  but tbh, the latency with the previous implementation where every note got its own oscillator node was really only noticeable if you tried to scroll
+  across the page (i.e. any user activity on the page while playback occurred). it was a good exercise I guess to try anyway.
+
 current things to do now:
 	- bug: 2 instruments, have a note that spans 6 columns, move to next isntrument, try placing note within area that note spans. it might not let you place a new note exactly.
 		- this might have to do with an existing note element (opacity is 0 b/c onion skin is off for that instrument it belongs to) in the parent cell


### PR DESCRIPTION
Basically this PR changes the way notes are scheduled. instead of creating a new node per note, we try to find the minimum number of nodes needed and reuse nodes. this seems to help reduce latency/glitching, especially when there is concurrent user activity on the page, i.e. scrolling across the piano roll during playback of a fairly long piece (i.e. 'nakayoshi sensation'). 

However, I'm not sure this is more favorable than the previous implementation, since the latency/glitching is really only noticeable when there is user activity during playback. also, due to this change, I think timing is more prone to being impacted since we don't actually tell oscillator nodes when to stop (except when you press stop) - this needs more investigating though.

I also removed the loop feature because it seemed a bit useless right now and the implementation was questionable (and I couldn't get it to work with my changes).

I do think I reorganized some things in maybe a more understandable way to make it easier to refactor in the future. I would like to see if it would be easy to change the implementation so that I can create a node per note instead if I want and if that's doable, this PR might be good to merge. :) 

update: so I tried creating an osc node for every note instead so I could call stop but that didn't seem to resolve anything (still had the slight lag at the end). not really sure what's different between this and the old way anyway other than that. I don't think my start/stop time calculations are wrong because if you start playback near the laggy part, everything sounds fine :/.