### PR TITLE
fix time drift and stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Disclaimer: the custom instrument functionality is currently pretty limited; the
     
 ### current next steps?:    
 - delete measures
-- still need to delete instruments.    
+- delete instruments
     
 ### features I would like to implement:    
 - ability to change color of highlight and color of note blocks, i.e. different for each instrument    
@@ -57,6 +57,8 @@ varying lengths and pitches with the help of a grid, put these notes in an array
 My implementation does not use the canvas element like some other piano roll implementations and instead relies on just DOM manipulation of a grid to manipulate notes.
 Users can place and move notes freely on the piano roll. In order to do that, my program looks at a couple of factors: the location of the cursor and the note lock size, which can be an 8th note (1 block on the piano roll), 16th note (half a block), or 32nd note. The note lock size determines the incremental distance a note block can be moved. The smaller the note, the more possible locations within a piano roll block it could be placed. For note movement, the cursor's location is taken into account and if it is over a piano roll block, my program determines, based on the cursor's x-position, what position within the piano roll block the cursor is closest to and places the note at that position.    
     
+Additionally, I wanted to keep it light, simple and easily portable so I minimized the number of dependencies (just jQuery! :D).    
+    
 For the context menus used to edit instruments and notes, I used the awesome jQuery contextMenu library provided here: https://swisnl.github.io/jQuery-contextMenu/. Thanks very much to them!
     
 ### demos:    
@@ -66,7 +68,7 @@ Sand Canyon (Kirby's Dream Land 3) - Jun Ishikawa
     
 3_4 time demo - my own composition    
     
-なかよしセンセーション (Princess Connect! Re:Dive) - 大久保 薫
+なかよしセンセーション (Princess Connect! Re:Dive) - Kaoru Okubo
 
 
     

--- a/main.js
+++ b/main.js
@@ -425,7 +425,12 @@ function validateProject(project){
 			
 	});
 	
-	return measures && tempo && composer && title && subdivision && instruments;
+	return measures && 
+		   tempo && 
+		   composer && 
+		   title && 
+		   subdivision && 
+		   instruments;
 }
 
 
@@ -466,6 +471,8 @@ function getDemo(selectedDemo){
 		clearGridAll(pianoRoll);
 		// reset playMarker if set 
 		pianoRoll.playMarker = null;
+		// stop playing if currently playing
+		stopPlay(pianoRoll);
 		var data = JSON.parse(httpRequest.responseText);
 		processData(data);
 	}

--- a/todo.txt
+++ b/todo.txt
@@ -8,12 +8,10 @@
 
 current things to do now:
 	- clicking a note -> if clicking an already existing note, the volume should reflect that note's volume. otherwise use the instrument's volume.
-
 	- bug: 2 instruments, have a note that spans 6 columns, move to next isntrument, try placing note within area that note spans. it might not let you place a new note exactly.
 		- this might have to do with an existing note element (opacity is 0 b/c onion skin is off for that instrument it belongs to) in the parent cell
 	- delete instrument functionality
 	- delete measure functionality
-	- if something is currently playing and a demo is switched, play should be turned off.
 	- improve percussion
 	- the pianoNotes div (i.e. mobile piano bar) implementation could be cleaned up a bit maybe?
 	- haven't found the exact cause yet but sometimes notes aren't getting picked up (maybe because of onion-skin) and you have to 
@@ -21,3 +19,4 @@ current things to do now:
 	- add metronome? is scheduler scheduling on time?
 	- accessibility?
 	- maybe make it at least a little mobile friendly, i.e. support also touch events?
+	- refactor? things like play and stopPlay - should those be piano roll methods instead of standalone functions?

--- a/todo.txt
+++ b/todo.txt
@@ -6,12 +6,6 @@
 - onion-skin sometimes prevents resizing ability? (can't reproduce currrently :/)
 - looping implementation was questionable and removed for now
 
-- looks like reducing the number of audio nodes helps performance in terms of less latency (yay!) but I think since we reuse nodes and don't
-  call stop on them for each note like we previously did, this doesn't quite make scheduling as on-point as it previously was (boooo!) and could
-  introduce a bit more lag time in the scheduling. not sure if having better scheduling is more favorable to have than latency due to number of nodes.
-  but tbh, the latency with the previous implementation where every note got its own oscillator node was really only noticeable if you tried to scroll
-  across the page (i.e. any user activity on the page while playback occurred). it was a good exercise I guess to try anyway.
-
 current things to do now:
 	- clicking a note -> if clicking an already existing note, the volume should reflect that note's volume. otherwise use the instrument's volume.
 
@@ -19,6 +13,7 @@ current things to do now:
 		- this might have to do with an existing note element (opacity is 0 b/c onion skin is off for that instrument it belongs to) in the parent cell
 	- delete instrument functionality
 	- delete measure functionality
+	- if something is currently playing and a demo is switched, play should be turned off.
 	- improve percussion
 	- the pianoNotes div (i.e. mobile piano bar) implementation could be cleaned up a bit maybe?
 	- haven't found the exact cause yet but sometimes notes aren't getting picked up (maybe because of onion-skin) and you have to 


### PR DESCRIPTION
Previously with 'long-ish' demos like 'nakayoshi sensation', which clocks in at least over a minute, towards the end it became apparent that some notes were lagging. This is because some chords had their notes starting at slightly different times, due to some weirdness when calculating their start time offsets (probably something to go back and check? I'm dealing with floats so maybe it's precision issues?).

Do note though that this current fix is per instrument. So if there's a chord that encompasses multiple instruments, it's possible for the lag to occur I think but at least for now this solves the issue pretty well. :D

Other stuff: I also made sure to stop playback if the user changes the demo while it's playing; made some small edits to the README