### PR TITLE
Add instrument color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Disclaimer: the custom instrument functionality is currently pretty limited; the
 - refactoring + tests    
     
 ### features I would like to implement:    
-- ability to change color of highlight and color of note blocks, i.e. different for each instrument    
 - be able to repeat a section    
 - looping
     

--- a/demos/nakayoshi sensation.json
+++ b/demos/nakayoshi sensation.json
@@ -9,8 +9,11 @@
         {
             "name": "Instrument 1",
             "volume": 0.1,
+            "pan": 0,
             "waveType": "sine",
             "onionSkinOn": true,
+            "noteColorStart": "rgb(121,201,255)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F6col_0": [
                     {
@@ -3703,8 +3706,11 @@
         {
             "name": "yuni",
             "volume": 0.1,
+            "pan": 0,
             "waveType": "triangle",
             "onionSkinOn": true,
+            "noteColorStart": "rgb(255,140,96)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F6col_104": [
                     {
@@ -5417,8 +5423,11 @@
         {
             "name": "chieru",
             "volume": 0.1,
+            "pan": 0,
             "waveType": "triangle",
             "onionSkinOn": true,
+            "noteColorStart": "rgb(255,121,194)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F6col_121": [
                     {
@@ -6809,8 +6818,11 @@
         {
             "name": "chloe",
             "volume": 0.25,
+            "pan": 0,
             "waveType": "sine",
             "onionSkinOn": true,
+            "noteColorStart": "rgb(255,238,109)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F6col_136": [
                     {
@@ -7997,8 +8009,11 @@
         {
             "name": "bass",
             "volume": 0.1,
+            "pan": 0,
             "waveType": "sawtooth",
             "onionSkinOn": false,
+            "noteColorStart": "rgb(0,158,52)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F3col_104": [
                     {
@@ -11397,8 +11412,11 @@
         {
             "name": "percussion",
             "volume": 0.25,
+            "pan": 0,
             "waveType": "percussion",
             "onionSkinOn": false,
+            "noteColorStart": "rgb(0,158,52)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "B2col_0": [
                     {
@@ -15221,8 +15239,11 @@
         {
             "name": "new_instrument",
             "volume": 0.1,
+            "pan": 0,
             "waveType": "sine",
             "onionSkinOn": true,
+            "noteColorStart": "rgb(0,158,52)",
+            "noteColorEnd": "rgb(52,208,0)",
             "notes": {
                 "F5col_40": [
                     {

--- a/src/classes.js
+++ b/src/classes.js
@@ -34,10 +34,10 @@ function PianoRoll(){
     
     // colors
     this.playMarkerColor = "rgb(50, 205, 50)";
-    this.highlightColor = "#FFFF99";
-    this.measureNumberColor = "#2980B9";
-    this.instrumentTableColor = 'rgb(188, 223, 70)';
-    this.currNotePlayingColor = 'rgb(112, 155, 224)';
+    this.highlightColor = "#FFFF99"; // yellow
+    this.measureNumberColor = "#2980B9"; // blue
+    this.instrumentTableColor = 'rgb(188, 223, 70)';  // green
+    this.currNotePlayingColor = 'rgb(112, 155, 224)'; // light blue
     
     // default instrument sounds and note styles
     this.defaultInstrumentSounds = {
@@ -231,6 +231,17 @@ function Instrument(name, gain, notesArray){
     this.pan = 0.0;
     this.isMute = false;
     this.onionSkinOn = true;
+    
+    // note color is a gradient
+    this.noteColorStart = "rgb(0,158,52)";
+    this.noteColorEnd = "rgb(52,208,0)";
+}
+
+function updateNoteColors(instrument){
+    for(var noteName in instrument.activeNotes){
+        // should be something like: linear-gradient(90deg, rgb(0, 158, 52) 90%, rgb(52, 208, 0) 99%)
+        instrument.activeNotes[noteName].style.background = `linear-gradient(90deg, ${instrument.noteColorStart} 90%, ${instrument.noteColorEnd} 99%)`;
+    }
 }
 
 /*****  NOTE CLASS ******/

--- a/src/domModification.js
+++ b/src/domModification.js
@@ -205,10 +205,12 @@ function mouseupHelper(newNote, pianoRollObject, pianoRollInterface, eventsToRem
 // creates a new html element representing a note 
 // @param pianoRollObject: an instance of PianoRoll
 function createNewNoteElement(pianoRollObject){
+    var currInst = pianoRollObject.currentInstrument;
+    
     var newNote = document.createElement('div');
-    newNote.setAttribute("data-volume", pianoRollObject.currentInstrument.volume);
+    newNote.setAttribute("data-volume", currInst.volume);
     newNote.setAttribute("data-type", "default"); 
-    newNote.style.background = "linear-gradient(90deg, rgba(0,158,52,1) 90%, rgba(52,208,0,1) 99%";
+    newNote.style.background = `linear-gradient(90deg, ${currInst.noteColorStart} 90%, ${currInst.noteColorEnd} 99%`;
     newNote.style.height = "15px";
     newNote.style.position = "absolute";
     newNote.style.opacity = 1.0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,6 +166,8 @@ function getJSONData(pianoRoll){
         instrumentData["pan"] = currInstrument["pan"];
         instrumentData["waveType"] = currInstrument["waveType"];
         instrumentData["onionSkinOn"] = currInstrument["onionSkinOn"];
+        instrumentData["noteColorStart"] = currInstrument["noteColorStart"];
+        instrumentData["noteColorEnd"] = currInstrument["noteColorEnd"];
         instrumentData["notes"] = {};
         for(var note in currInstrument.activeNotes){
             var noteElement = currInstrument.activeNotes[note];
@@ -273,6 +275,7 @@ function processData(data){
         addNewInstrument(data.instruments[i].name, false, pianoRoll);
         
         var newInstrument = data.instruments[i];
+        
         // TODO: this is not ideal if we need to add more instrument attributes
         if(newInstrument.pan === undefined){
             newInstrument.pan = 0.0;
@@ -307,6 +310,13 @@ function processData(data){
             });
         }
         newInstrument.notes = readInNotes(newInstrument, pianoRoll);
+        
+        if(newInstrument.noteColorStart === undefined){
+            newInstrument.noteColorStart = "rgb(0,158,52)";
+            newInstrument.noteColorEnd = "rgb(52,208,0)";
+        }else{
+            updateNoteColors(newInstrument);
+        }
         
         // add new instrument to array
         pianoRoll.instruments.push(newInstrument);

--- a/tests/classes - spec.js
+++ b/tests/classes - spec.js
@@ -38,6 +38,8 @@ describe('testing classes.js', function(){
         expect(instrument.name).to.equal('test');
         expect(instrument.onionSkinOn).to.be.true;
         expect(instrument.isMute).to.be.false;
+        expect(instrument.noteColorStart).to.not.be.undefined;
+        expect(instrument.noteColorEnd).to.not.be.undefined;
     });
     
     it('testing ElementNode class', function(){


### PR DESCRIPTION
Added the ability to customize the color for an instrument's notes within the instrument's context menu.

![piano-roll-browser-color2](https://user-images.githubusercontent.com/8601582/222923034-724f8c6e-6bfe-44eb-ae01-77e8301df0d3.png)

![piano-roll-browser-color1](https://user-images.githubusercontent.com/8601582/222922983-c8e1c48b-8786-4267-bcf9-2204cf70fac5.png)

