### PR TITLE
reduce layout thrashing

### DIFF
--- a/src/domModification.js
+++ b/src/domModification.js
@@ -374,13 +374,13 @@ function addNewMeasure(pianoRollObject, container){
   // start at the index of C8
   for(let j = startIndex; j < noteRowsChildren.length; j++){
     const rowParent = noteRowsChildren[j];
+    const pitch = rowParent.id;
     for(let k = 0; k < pianoRollObject.subdivision; k++){
-      const newColumnCell = createColumnCell(rowParent.id, lastColNum+k-1, pianoRollObject);
+      const newColumnCell = createColumnCell(pitch, lastColNum+k-1, pianoRollObject);
       rowParent.appendChild(newColumnCell);
     }
-    // adjust width of row
-    rowParent.style.width = rowParent.scrollWidth + "px";
   }
+  
   pianoRollObject.numberOfMeasures++;
 }
 
@@ -609,7 +609,7 @@ function redrawCellBorders(pianoRollObject, headerId){
   for(let i = 1; i < headers.length; i++){
     const columnHeader = headers[i];
     const colNum = parseInt(headers[i].id.match(/\d+/g)[0]);
-    columnHeader.innerHTML = "";
+    columnHeader.textContent = "";
     columnHeader.className = "thinBorder";
         
     const subdiv = (i % subdivision) === 0 ? subdivision : (i % subdivision);
@@ -617,7 +617,7 @@ function redrawCellBorders(pianoRollObject, headerId){
     // mark the measure number 
     if(subdiv === 1){
       const measureNumber = document.createElement("h2");
-      measureNumber.innerHTML = measureCounter++;
+      measureNumber.textContent = measureCounter++;
       measureNumber.style.margin = '0 0 0 0';
       measureNumber.style.color = pianoRollObject.measureNumberColor;
             
@@ -695,9 +695,9 @@ function addNewInstrument(name, createBool, pianoRollObject){
   newInstrument.style.backgroundColor = "transparent";
     
   if(name === undefined){
-    newInstrument.innerHTML = "new_instrument";
+    newInstrument.textContent = "new_instrument";
   }else{
-    newInstrument.innerHTML = name;
+    newInstrument.textContent = name;
   }
   newInstrument.addEventListener('click', function(event){
     // pass the event target's id to chooseInstrument()


### PR DESCRIPTION
... and get a significant performance improvement by removing some actually unnecessary HTML element style reading/setting code!

**before (notice there's a perceptible rendering delay when selecting a demo):**
![piano-roll-layout-thrashing](https://github.com/user-attachments/assets/936af235-245d-4ee4-991a-3f76661446f7)

**after (almost instantaneous rendering of the demo):**
![piano-roll-improvement](https://github.com/user-attachments/assets/4b3db03c-34b4-434c-8132-25f3da93dcdc)

and of course having hard data/numbers is very helpful :)

**before changes:**
run1 - ~1879 ms to render demo (Intrada - Pezel)
run2 - ~1626 ms to render demo (Intrada - Pezel)
run3 - ~1162 ms to render demo (Intrada - Pezel)

![piano-roll-layout-thrash1](https://github.com/user-attachments/assets/92b11f41-a77a-4328-8799-98ef9d92326d)
![piano-roll-layout-thrash2](https://github.com/user-attachments/assets/e17c72e3-435c-4add-aa37-ebbaf59c916a)
![layout-thrashing-piano-roll3](https://github.com/user-attachments/assets/bbbc7489-a577-4950-811b-47b5da37626f)

bottleneck in the code:
![layout-thrashing-piano-roll1](https://github.com/user-attachments/assets/d37f5d6e-1fc8-4d76-ac94-78756a2b8e50)

**with changes:**
run1 - ~184 ms to render demo (Intrada - Pezel)
run2 - ~482 ms to render demo (Intrada - Pezel)
run3 - ~370 ms to render demo (Intrada - Pezel)

![piano-roll-improvement1](https://github.com/user-attachments/assets/fda3a8c4-df88-472d-8269-ffe8d08b4bda)
![piano-roll-improvement2](https://github.com/user-attachments/assets/90218411-ab60-425f-84e0-6064234a340f)
![piano-roll-improvement3](https://github.com/user-attachments/assets/42cfd60e-6b37-43ad-92cd-220a72deb260)

so on average the time was at least halved by removing the unnecessary code that was reading and updating styles! :D This is a helpful read: https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing

I also changed some usage of `innerHTML` to `textContent` as `innerHTML` seemed unnecessary.
