### PR TITLE
fix yellow highlight over row so it spans entire container when scrolled

### DIFF
--- a/src/gridBuilder.js
+++ b/src/gridBuilder.js
@@ -105,13 +105,14 @@ function buildGrid(gridDivId, pianoRollObject){
     //first create new element for new pitch
     const newRow = document.createElement('div');
     newRow.id = replaceSharp(note);
+    newRow.style.display = "table-row";
         
     // this creates the notes on the left of the piano roll. it is static.
     const newRowText = document.createElement('div');
     newRowText.innerHTML = note.substring(0, note.length - 1) + "<sub>" + note[note.length-1] + "</sub>";
-    newRowText.style.fontSize = '11px';
+    newRowText.style.fontSize = "11px";
     newRowText.style.border = "1px solid #000";
-    newRowText.style.display = 'inline-block';
+    newRowText.style.display = "inline-block";
     newRowText.style.width = "50px";
     newRowText.style.verticalAlign = "middle";
         
@@ -143,7 +144,6 @@ function createColumnCell(pitch, colNum, pianoRollObject){
   column.style.display = 'inline-block';
   column.style.width = "40px";
   column.style.height = "15px";
-  column.style.zIndex = "5";
   column.style.verticalAlign = "middle";
   column.style.backgroundColor = "transparent";
   column.setAttribute("data-type", "default"); 

--- a/tests/testing-scenarios.txt
+++ b/tests/testing-scenarios.txt
@@ -5,6 +5,7 @@ notes
 - remove a note
 - change volume
 - change style
+- make sure yellow row highlight on mouseover spans the whole container, even when scrolled
 
 instruments
 - add an instrument


### PR DESCRIPTION
🤦 so I failed to check this with my [last PR](https://github.com/syncopika/piano_roll_browser/pull/42) but it turns out this line that was causing significant layout thrashing:
```
rowParent.style.width = rowParent.scrollWidth + "px";
```
helped set the width of the rowParent when adding new measures so that the yellow highlight when mouseover'ing a row covers the whole row as it grows. so with that line gone, it looks like this:
![piano-roll-row-highlight-issue](https://github.com/user-attachments/assets/d6b8cbd6-b570-4bb0-82d8-63f81e0d5373)

thankfully though, it does appear to be unnecessary to keep updating the row parent and setting an explicit width. 

thanks to https://stackoverflow.com/questions/34561989/how-to-make-divs-width-to-expand-within-scrollable-content, it looks like setting the row parent elements to be `display: table-row` gets us the desired result:
![piano-roll-row-highlight-issue-fix](https://github.com/user-attachments/assets/269cb710-77a9-450b-b63f-9e3138afafe0)

I also removed a z-index setting that appeared to be pointless based on the dev console:
![image](https://github.com/user-attachments/assets/d0180461-a26f-4d35-955e-2188a48df17c)
