### PR TITLE
Add new 'ripples' visualizer idea

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
         </li>
         
         <li>
-          <button id='toggleRipplesVisualizer' title='toggle ripple visualizer' class='btn'>
+          <button id='toggleRipplesVisualizer' title='toggle ripples visualizer' class='btn'>
             <svg viewBox="0 0 24 24" width="38" height="38">
               <circle cx="8" cy="8" r="5" stroke="black" stroke-width="1" fill="none"></circle>
               <circle cx="8" cy="8" r="2" stroke="black" stroke-width="0.5" fill="none"></circle>

--- a/index.html
+++ b/index.html
@@ -421,6 +421,19 @@
             </svg>
           </button>
         </li>
+        
+        <li>
+          <button id='toggleRipplesVisualizer' title='toggle ripple visualizer' class='btn'>
+            <svg viewBox="0 0 24 24" width="38" height="38">
+              <circle cx="8" cy="8" r="5" stroke="black" stroke-width="1" fill="none"></circle>
+              <circle cx="8" cy="8" r="2" stroke="black" stroke-width="0.5" fill="none"></circle>
+              <circle cx="8" cy="8" r="8" stroke="black" stroke-width="0.8" fill="none"></circle>
+              <circle cx="20" cy="20" r="4" stroke="black" stroke-width="1" fill="none"></circle>
+              <circle cx="20" cy="20" r="1" stroke="black" stroke-width="0.5" fill="none"></circle>
+              <circle cx="20" cy="20" r="7" stroke="black" stroke-width="0.8" fill="none"></circle>
+            </svg>
+          </button>
+        </li>
       </ul>
         
       <div id='demo'>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,8 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 // flag for toggling the toolbar to be static or sticky
+// this gets used in utils.js
+// eslint-disable-next-line prefer-const
 let toggleStickyToolbar = false;
 
 // set up piano roll

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 // flag for toggling the toolbar to be static or sticky
-const toggleStickyToolbar = false;
+let toggleStickyToolbar = false;
 
 // set up piano roll
 const pianoRoll = new PianoRoll();

--- a/src/classes.js
+++ b/src/classes.js
@@ -35,6 +35,7 @@ function PianoRoll(){
     
   // stuff needed for the visualizer
   this.showVisualizer = false;
+  this.selectedVizualizer = null;
   this.analyserNode = null;
   this.visualizerCanvas = null;
   this.visualizerOffscreenCanvas = null;

--- a/src/classes.js
+++ b/src/classes.js
@@ -34,7 +34,6 @@ function PianoRoll(){
   this.noiseBuffer;                    // for percussion
     
   // stuff needed for the visualizer
-  this.showVisualizer = false;
   this.selectedVizualizer = null;
   this.analyserNode = null;
   this.visualizerCanvas = null;

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -667,12 +667,15 @@ function scheduler(pianoRoll, allInstruments){
         const startTime = thisTime + startTimeOffset;
         const endTime = startTime + duration;
         const otherParams = note.note;
+        const boundingRect = document.getElementById(otherParams.block.id).getBoundingClientRect();
         // don't rely on thisTime because that's audioContext.currentTime, which only ever increases
         visualizerNotes.push({
           start: now + (startTimeOffset * 1000),
           end: now + ((startTimeOffset + duration) * 1000),
           volume,
           freq: otherParams.freq,
+          x: boundingRect.x,
+          y: boundingRect.y,
         });
       });
     }

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -651,9 +651,7 @@ function scheduler(pianoRoll, allInstruments){
   }
   
   // for ripples visualizer
-  if(pianoRoll.showVisualizer && pianoRoll.visualizerCanvas && pianoRoll.selectedVisualizer === 'ripples'){
-    //console.log(pianoRollObject.currentInstrument.notes);
-    //updateRipplesVisualizer(pianoRollObject, pianoRollObject.currentInstrument.notes);
+  if(pianoRoll.visualizerCanvas && pianoRoll.selectedVisualizer === 'ripples'){
     const visualizerNotes = [];
     const now = Date.now();
     for(const i in instrumentsToPlay){
@@ -669,9 +667,10 @@ function scheduler(pianoRoll, allInstruments){
         const startTime = thisTime + startTimeOffset;
         const endTime = startTime + duration;
         const otherParams = note.note;
+        // don't rely on thisTime because that's audioContext.currentTime, which only ever increases
         visualizerNotes.push({
-          start: now + (startTime * 1000),
-          end: now + (endTime * 1000),
+          start: now + (startTimeOffset * 1000),
+          end: now + ((startTimeOffset + duration) * 1000),
           volume,
           freq: otherParams.freq,
         });

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -649,6 +649,36 @@ function scheduler(pianoRoll, allInstruments){
       });
     });
   }
+  
+  // for ripples visualizer
+  if(pianoRoll.showVisualizer && pianoRoll.visualizerCanvas && pianoRoll.selectedVisualizer === 'ripples'){
+    //console.log(pianoRollObject.currentInstrument.notes);
+    //updateRipplesVisualizer(pianoRollObject, pianoRollObject.currentInstrument.notes);
+    const visualizerNotes = [];
+    const now = Date.now();
+    for(const i in instrumentsToPlay){
+      const currInstNotes = allNotesPerInstrument[i];
+      if(currInstNotes === undefined){
+        // no notes for this instrument
+        continue;
+      }
+      currInstNotes.forEach((note) => {
+        const duration = note.duration;
+        const volume = note.volume;
+        const startTimeOffset = note.startTimeOffset;
+        const startTime = thisTime + startTimeOffset;
+        const endTime = startTime + duration;
+        const otherParams = note.note;
+        visualizerNotes.push({
+          start: now + (startTime * 1000),
+          end: now + (endTime * 1000),
+          volume,
+          freq: otherParams.freq,
+        });
+      });
+    }
+    updateRipplesVisualizer(pianoRoll, visualizerNotes);
+  }
     
   for(const i in instrumentsToPlay){
     const currInstNotes = allNotesPerInstrument[i];

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -416,7 +416,7 @@ function configureInstrumentNotes(routes, pianoRollObject, instrumentGainNodes, 
           panNode.connect(pianoRollObject.audioContextDestMediaStream);
         }
                 
-        if(pianoRollObject.showVisualizer){
+        if(pianoRollObject.selectedVisualizer === 'wave'){
           panNode.connect(pianoRollObject.analyserNode);
         }else{
           panNode.connect(pianoRollObject.audioContextDestOriginal);
@@ -903,7 +903,7 @@ function pausePlay(pianoRollObject){
     // create a new gain for each instrument (this really is only needed when clicking notes, not playback)
     const newGain = initGain(pianoRollObject.audioContext);
         
-    if(pianoRollObject.showVisualizer){
+    if(pianoRollObject.selectedVisualizer === 'wave'){
       newGain.connect(pianoRollObject.analyserNode);
     }else{
       newGain.connect(pianoRollObject.audioContext.destination);
@@ -937,7 +937,7 @@ function stopPlay(pianoRollObject){
     // create a new gain for each instrument (this really is only needed when clicking notes, not playback)
     const newGain = initGain(pianoRollObject.audioContext);
         
-    if(pianoRollObject.showVisualizer){
+    if(pianoRollObject.selectedVisualizer === 'wave'){
       newGain.connect(pianoRollObject.analyserNode);
     }else{
       newGain.connect(pianoRollObject.audioContext.destination);
@@ -980,7 +980,7 @@ function createNewInstrument(name, pianoRollObject){
   // make new gain node for the instrument 
   const newGain = initGain(pianoRollObject.audioContext);
     
-  if(pianoRollObject.showVisualizer){
+  if(pianoRollObject.selectedVisualizer === 'wave'){
     newGain.connect(pianoRollObject.analyserNode);
   }else{
     newGain.connect(pianoRollObject.audioContext.destination);

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,10 +76,16 @@ function bindButtons(pianoRollObject){
     pianoRoll.showVisualizer = !pianoRoll.showVisualizer;
     document.getElementById('toggleVisualizer').style.backgroundColor = pianoRoll.showVisualizer ? "#d0d0d0" : "";
     if(pianoRoll.showVisualizer){
-      pianoRoll.visualizerRequestAnimationFrameId = window.requestAnimationFrame((timestamp) => updateVisualizer(pianoRoll));
+      //pianoRoll.visualizerRequestAnimationFrameId = window.requestAnimationFrame((timestamp) => updateVisualizer(pianoRoll)); // regular wave visualizer
+      pianoRoll.selectedVisualizer = 'ripples';
     }else{
       cancelAnimationFrame(pianoRoll.visualizerRequestAnimationFrameId);
       pianoRoll.visualizerRequestAnimationFrameId = null;
+      
+      if(pianoRoll.selectedVisualizer === 'ripples'){
+        // stop the ripple visualizer
+        updateRipplesVisualizer(pianoRoll, [], true);
+      }
     }
   });
     

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ function bindButtons(pianoRollObject){
         deleteMeasure(pianoRollObject);
                 
         // update ui with correct num measures
-        const measureCounterElement = document.getElementById("measures");
+        const measureCounterElement = document.getElementById('measures');
         measureCounterElement.textContent = "measure count: " + pianoRollObject.numberOfMeasures;
       }
     }
@@ -29,7 +29,7 @@ function bindButtons(pianoRollObject){
   document.getElementById('addMeasure').addEventListener('click', function(){
     addNewMeasure(pianoRollObject, document.getElementById('columnHeaderRow'));
         
-    const measureCounterElement = document.getElementById("measures");
+    const measureCounterElement = document.getElementById('measures');
     measureCounterElement.textContent = "measure count: " + pianoRollObject.numberOfMeasures;
   });
     
@@ -66,6 +66,11 @@ function bindButtons(pianoRollObject){
     
   document.getElementById('stopPlay').addEventListener('click', function(){
     stopPlay(pianoRoll);
+    
+    if(pianoRoll.visualizerCanvas && pianoRoll.selectedVisualizer === 'ripples'){
+      // stop the visualizer
+      updateRipplesVisualizer(pianoRoll, [], true);
+    }
         
     if(pianoRoll.visualizerCanvas){
       removeVisualizer(pianoRoll);
@@ -76,6 +81,7 @@ function bindButtons(pianoRollObject){
     pianoRoll.showVisualizer = !pianoRoll.showVisualizer;
     document.getElementById('toggleVisualizer').style.backgroundColor = pianoRoll.showVisualizer ? "#d0d0d0" : "";
     if(pianoRoll.showVisualizer){
+      // TODO: allow user to choose between regular wave visualizer and ripples visualizer
       //pianoRoll.visualizerRequestAnimationFrameId = window.requestAnimationFrame((timestamp) => updateVisualizer(pianoRoll)); // regular wave visualizer
       pianoRoll.selectedVisualizer = 'ripples';
     }else{
@@ -101,7 +107,7 @@ function bindButtons(pianoRollObject){
     }
   });
     
-  document.getElementById("changeTempo").addEventListener('change', function(){
+  document.getElementById('changeTempo').addEventListener('change', function(){
     changeTempo(pianoRoll, this);
   });
     

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,7 @@ function bindButtons(pianoRollObject){
       if(pianoRoll.selectedVisualizer){
         buildVisualizer('grid', pianoRoll);
         if(pianoRoll.selectedVisualizer === 'wave'){
-            updateVisualizer(pianoRoll);
+          updateVisualizer(pianoRoll);
         }
       }
       play(pianoRoll);
@@ -63,7 +63,7 @@ function bindButtons(pianoRollObject){
       if(pianoRoll.selectedVisualizer){
         buildVisualizer('grid', pianoRoll);
         if(pianoRoll.selectedVisualizer === 'wave'){
-            updateVisualizer(pianoRoll);
+          updateVisualizer(pianoRoll);
         }
       }
       playAll(pianoRoll);

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -52,6 +52,30 @@ function updateVisualizer(pianoRollObject){
     window.requestAnimationFrame((timestamp) => updateVisualizer(pianoRollObject)); 
 }
 
+// for passing note data for note ripples visualization
+// we will pass data for ALL notes of a piece to the worker (is this a bad idea?? ¯\_(ツ)_/¯)
+// I think it's easier to work with requestAnimationFrame this way
+function updateRipplesVisualizer(pianoRollObject, noteData, stop=false){
+  // noteData should be an array of objects, with each object representing a note of the piece
+  // each object in noteData should look like:
+  // {
+  //  start: noteStart, // should be unix timestamp
+  //  end: noteEnd, // unix timestamp
+  //  freq: number,
+  //  color, // string, e.g. rgb(x,y,z)
+  // }
+  //
+  if(pianoRollObject.visualizerCanvas){
+    pianoRollObject.visualizerWebWorker.postMessage(
+      [{
+        visualizationType: 'ripples',
+        stop: false,
+        data: noteData,
+      }]
+    );
+  }
+}
+
 function removeVisualizer(pianoRollObject){
   if(pianoRollObject.visualizerCanvas){
     pianoRollObject.visualizerCanvas.parentNode.removeChild(pianoRollObject.visualizerCanvas);

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -24,6 +24,7 @@ function buildVisualizer(gridDivId, pianoRollObject){
   thePiano.appendChild(canvas);
     
   pianoRollObject.visualizerCanvas = canvas;
+  
   pianoRollObject.visualizerWebWorker = new Worker('./src/visualizerWorker.js');
     
   const offscreen = canvas.transferControlToOffscreen();
@@ -69,7 +70,7 @@ function updateRipplesVisualizer(pianoRollObject, noteData, stop=false){
     pianoRollObject.visualizerWebWorker.postMessage(
       [{
         visualizationType: 'ripples',
-        stop: false,
+        stop,
         data: noteData,
       }]
     );
@@ -81,6 +82,7 @@ function removeVisualizer(pianoRollObject){
     pianoRollObject.visualizerCanvas.parentNode.removeChild(pianoRollObject.visualizerCanvas);
     pianoRollObject.visualizerCanvas = null;
     pianoRollObject.visualizerOffscreenCanvas = null;
+    pianoRollObject.visualizerWebWorker.terminate(); // important!
     pianoRollObject.visualizerWebWorker = null;
   }
 }

--- a/src/visualizerWorker.js
+++ b/src/visualizerWorker.js
@@ -69,7 +69,6 @@ class Ripple {
   lineCaps = ['butt', 'round', 'square'];
   
   constructor(canvasCtx, x, y, start){
-    this.type = type;
     this.speed = Math.random() + 0.2;
     this.color = this.colors[Math.floor(Math.random() * this.colors.length)];
     this.lineCap = this.lineCaps[Math.floor(Math.random() * this.lineCaps.length)];
@@ -153,7 +152,7 @@ function drawRipplesVisualization(data, canvas){
   ripples = data.map(d => {
     const x = Math.random() * width;
     const y = Math.random() * height;
-    return new Ripple(ctx, x, y, d.start);
+    return new Ripple(ctx, d.x, d.y, d.start);
   });
   
   renderRipples();

--- a/src/visualizerWorker.js
+++ b/src/visualizerWorker.js
@@ -3,14 +3,29 @@
 
 let canvas = null;
 
+// for note ripples visualizer
+let ripples = [];
+
+let visualizerIsRunning = false;
+let stopVisualizer = false;
+
 self.onmessage = function(msg){
   //console.log(msg);
     
   if(msg.data.canvas){
     canvas = msg.data.canvas;
   }else{
-    const data = msg.data[0].data;
-    drawVisualization(data, canvas);
+    if(msg.data[0].visualizationType === 'ripples'){
+      const stop = msg.data[0].stop;
+      if(!stop && !visualizerIsRunning){
+        const data = msg.data[0].data;
+        drawRipplesVisualization(data, canvas);
+        visualizerIsRunning = true;
+      }
+    }else{
+      const data = msg.data[0].data;
+      drawVisualization(data, canvas);
+    }
   }
 };
 
@@ -22,11 +37,8 @@ function drawVisualization(data, canvas){
   //console.log(`width: ${width}, height: ${height}, buffer len: ${bufferLen}`);
     
   const ctx = canvas.getContext('2d');
-    
   ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-    
   ctx.clearRect(0, 0, width, height);
-    
   ctx.lineWidth = 1;
   ctx.strokeStyle = 'rgb(0, 0, 0)';
   ctx.beginPath();
@@ -48,4 +60,119 @@ function drawVisualization(data, canvas){
   }
     
   ctx.stroke();
+}
+
+class Ripple {
+  lights = [];
+  colors = ['red', 'black', 'yellow', 'green', 'blue', 'pink', 'purple'];
+  lineCaps = ['butt', 'round', 'square'];
+  
+  constructor(type, canvasCtx, x, y, start){
+    this.type = type;
+    this.radius = 90 * Math.random() + 10;
+    this.speed = 2 * Math.random() + 0.2;
+    this.color = this.colors[Math.floor(Math.random() * this.colors.length)];
+    this.lineCap = this.lineCaps[Math.floor(Math.random() * this.lineCaps.length)];
+    this.ctx = canvasCtx;
+    this.startX = x;
+    this.startY = y;
+    this.startTime = start;
+    this.isFinished = false;
+    
+    let deg = 0;
+    const slices = 8;
+    const sliceDeg = 360 / slices;
+    for(let i = 0; i < slices; i++){
+      this.lights.push({
+        forward: {x: Math.cos(deg * Math.PI / 180), y: Math.sin(deg * Math.PI / 180)},
+        currX: x,
+        currY: y,
+        currWidth: 18 * Math.random() + 1, // TODO: set random line width per firework instead of per light?
+        done: false,
+      });
+      
+      deg += sliceDeg;
+    }
+  }
+    
+  distance(currX, currY){
+    const xDelta = currX - this.startX;
+    const yDelta = currY - this.startY;
+    return Math.sqrt((xDelta * xDelta) + (yDelta * yDelta));
+  }
+  
+  render(){
+    const now = Date.now();
+    if(this.lights && now >= this.startTime){
+      this.lights.forEach(l => {
+        if(!l.done){
+          if(this.type === 'circle'){
+            if(this.distance(l.currX, l.currY) < this.radius){
+              const nextX = l.currX + (l.forward.x * this.speed);
+              const nextY = l.currY + (l.forward.y * this.speed);
+              this.ctx.strokeStyle = this.color;
+              this.ctx.lineCap = this.lineCap;
+              this.ctx.lineWidth = l.currWidth;
+              this.ctx.beginPath();
+              this.ctx.moveTo(nextX, nextY);
+              this.ctx.lineTo(nextX, nextY + 1); // this.ctx.lineTo(nextX + 1, nextY + 1); for slanted lights
+              this.ctx.closePath();
+              this.ctx.stroke();
+              l.currX = nextX;
+              l.currY = nextY;
+              l.currWidth -= 1;
+            }else{
+              l.done = true;
+            }
+          }
+        }
+      });
+      this.lights = this.lights.filter(l => !l.done);
+      if(this.lights.length === 0){
+        //console.log('done rendering firework');
+        this.isFinished = true;
+      }
+    }
+  }
+}
+
+function renderRipples(){
+  if(stopVisualizer){
+    visualizerIsRunning = false;
+    ripples = [];
+    return;
+  }
+  
+  if(canvas){
+    //console.log("rendering ripples");
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+        
+    ripples.forEach(f => f.render());
+    ripples = ripples.filter(f => !f.isFinished);
+    
+    if(ripples.length === 0){
+      visualizerIsRunning = false;
+    }
+    
+    if(ripples.length > 0){
+      requestAnimationFrame(renderRipples);
+    }
+  }
+}
+
+function drawRipplesVisualization(data, canvas){
+  const width = canvas.width;
+  const height = canvas.height;
+  const ctx = canvas.getContext('2d');
+  
+  // use requestAnimationFrame to draw the notes as needed as ripples
+  //console.log('hello from the web worker!');
+  //console.log(data);
+  const x = Math.random() * width;
+  const y = Math.random() * height;
+  
+  ripples = data.map(d => new Ripple('circle', ctx, x, y, d.start));
+  
+  renderRipples();
 }

--- a/src/visualizerWorker.js
+++ b/src/visualizerWorker.js
@@ -129,7 +129,7 @@ function renderRipples(){
     //console.log("rendering ripples");
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-        
+    
     ripples.forEach(f => f.render());
     ripples = ripples.filter(f => !f.isFinished);
     


### PR DESCRIPTION
This PR adds a new visualizer idea that shows a 'ripple' effect for each note on playback, if turned on.

![image](https://github.com/user-attachments/assets/4ae32efe-3484-4138-adfb-9cb619249028)

this gif is a bit fast but hopefully the effect is clear:
![20-01-2025_103415](https://github.com/user-attachments/assets/b9581219-36e5-4d15-9687-3c2e4880fb9d)

note that when toggling between visualizers, you will need to stop and restart playback for the new visualizer to take effect. 

also, the location of the ripples is something that needs to be reworked in the future - currently it just uses a note's bounding client rect's x and y coords but fails to correct for scroll and other things that might affect absolute x and y position (in other words, scroll does affect the ripples' positioning atm).

additionally, I finally added a web worker termination step so we shouldn't be potentially needlessly creating a bunch of web workers lol. and I fixed a bug with the sticky toolbar that I failed to notice for a good while 🤦‍♂️.
