### PR TITLE
some fixes and findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ also influenced a bit by PxTone Collage, another great application!
 - each note is customizable    
 - togglable onion skin    
 - recordable    
-- has a visualizer (although may be a bit buggy atm)    
+- has a couple visualizers (although may be a bit buggy atm and doesn't seem to work for any projects that have more than 51 measures)    
 ![visualizer](screenshots/visualizer.gif "visualizer")    
     
 ### instructions:    
@@ -48,8 +48,10 @@ I've also implemented a rudimentary custom instrument preset import ability (use
     
 Disclaimer: the custom instrument functionality is currently pretty limited; there are lots of possible custom preset configurations that will break under my current implementation. So this feature is definitely a work-in-progress but you can maybe at least see its future potential! :)    
     
-### current issues:        
+### current issues/limitations:        
 - (Chrome) downloading the audio isn't great - the audio comes out fine but the duration is messed up (see: https://stackoverflow.com/questions/38443084/how-can-i-add-predefined-length-to-audio-recorded-from-mediarecorder-in-chrome).    
+- visualization doesn't work for projects that are more than 51 measures long
+- projects longer than 51 measures may experience some lag with some notes on playback (probably due to the way I'm scheduling notes for playback)
     
 ### current next steps?:    
 - refactoring + tests    

--- a/index.html
+++ b/index.html
@@ -311,7 +311,6 @@
             </svg>
           </button>
         </li>
-        <input type='file' id='importFile' style='display: none'>
 
         <li>
           <button id='importInstrumentPreset' title='import new sound' class='btn'>

--- a/src/playbackFunctionality.js
+++ b/src/playbackFunctionality.js
@@ -671,14 +671,16 @@ function scheduler(pianoRoll, allInstruments){
         const vizCanvas = pianoRoll.visualizerCanvas.getBoundingClientRect();
         
         // don't rely on thisTime because that's audioContext.currentTime, which only ever increases
-        visualizerNotes.push({
+        const vizNote = {
           start: now + (startTimeOffset * 1000),
           end: now + ((startTimeOffset + duration) * 1000),
           volume,
           freq: otherParams.freq,
           x: boundingRect.x - vizCanvas.x, // account for offset of visualizer canvas
           y: boundingRect.y - vizCanvas.y,
-        });
+        };
+        
+        visualizerNotes.push(vizNote);
       });
     }
     updateRipplesVisualizer(pianoRoll, visualizerNotes);
@@ -888,6 +890,7 @@ function recordPlay(pianoRollObject){
 // @param pianoRollObject: an instance of PianoRoll
 function pausePlay(pianoRollObject){
   // highlightHeader comes from gridBuilder.js
+  // set play marker to where we paused so playback can begin at that spot on the next play
   highlightHeader(pianoRollObject.lastNoteColumn.id, pianoRollObject);
   
   pianoRollObject.isPlaying = false;
@@ -955,13 +958,6 @@ function stopPlay(pianoRollObject){
   if(pianoRollObject.lastNoteColumn && pianoRollObject.lastNoteColumn.id !== pianoRollObject.playMarker){
     pianoRollObject.lastNoteColumn.style.backgroundColor = '#fff';
   }
-    
-  // clear play marker if set
-  const prevMarker = document.getElementById(pianoRollObject.playMarker);
-  if(prevMarker){
-    prevMarker.style.backgroundColor = "#fff";
-  }
-  pianoRollObject.playMarker = null;
     
   // if recording
   if(pianoRollObject.recording){

--- a/src/utils.js
+++ b/src/utils.js
@@ -349,6 +349,9 @@ import JSON data from file
 
 ****/
 function processData(data){
+  // TODO: some visual notification of project loading would be nice
+  console.log('loading project...');
+  
   // update metadata 
   document.getElementById("composer").textContent = data.composer; // could be undefined!
   document.getElementById("pieceTitle").textContent = data.title; // could be undefined!
@@ -460,11 +463,14 @@ function processData(data){
   instrument1.classList.add("context-menu-instrument");
     
   pianoRoll.currentInstrument = pianoRoll.instruments[0];
+  
+  console.log('done loading project!');
 }
 
 function fileHandler(){
   //initiate file choosing after button click
-  const input = document.getElementById('importFile');
+  const input = document.createElement('input');
+  input.type = 'file';
   input.addEventListener('change', getFile, false);
   input.click();
 }
@@ -472,15 +478,17 @@ function fileHandler(){
 function getFile(e){
   const reader = new FileReader();
   const file = e.target.files[0];
-    
-  //when the image loads, put it on the canvas.
+  console.log(`got file: ${file.name}`);
   reader.onload = (function(theFile){
     return function(e){
             
       const data = JSON.parse(e.target.result);
-            
+
+      console.log('attempting to load project...');
+       
       // make sure project is valid
       if(!validateProject(data)){
+        console.log('invalid project!');
         return;
       }
             

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -1,4 +1,9 @@
 // for visualizing the piano roll
+//
+// WARNING: visualization appears to not work after exceeding a certain width, e.g. past 51 measures,
+// the visualizer seems to not draw anything. 51 measures seems to be the max width of the canvas allowable for visualization.
+// See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/canvas about max canvas size.
+// I guess it makes sense though that my visualization strategy using the HTML Canvas isn't infinitely scalable lol.
 
 // @param gridDivId: a string representing an HTML element id of the grid
 // @param pianoRollObject: an instance of PianoRoll 

--- a/src/visualizerWorker.js
+++ b/src/visualizerWorker.js
@@ -32,12 +32,12 @@ self.onmessage = function(msg){
       // wave visualizer
       const data = msg.data[0].data;
       const stop = msg.data[0].stop;
-      drawVisualization(data, canvas, stop);
+      drawWaveVisualization(data, canvas, stop);
     }
   }
 };
 
-function drawVisualization(data, canvas, stop){
+function drawWaveVisualization(data, canvas, stop){
   const width = canvas.width;
   const height = canvas.height;
   const bufferLen = data.length;
@@ -162,8 +162,6 @@ function drawRipplesVisualization(data, canvas){
   const ctx = canvas.getContext('2d');
   
   ripples = data.map(d => {
-    const x = Math.random() * width;
-    const y = Math.random() * height;
     return new Ripple(ctx, d.x, d.y, d.start);
   });
   


### PR DESCRIPTION
- made playback marker sticky (e.g. if you click on a column header to start playback at, play, then press stop, the start marker will stay there until you click it again to remove it)
- fixed what I think was an issue with project loading not working sometimes (e.g. if you load a demo, import a project, load another demo again and then try importing another project, it should work now). not exactly sure what the issue was but maybe it had to do with trying to add the same event listener for the file picker logic every time the import project function was called?
- investigated visualization not working for projects longer than 50 measures and documented some notes. basically I've discovered the limit in terms of project measure length before visualization will fail :D.
- I also think the limit before audio degradation begins to occur (in the form of lagging notes due to scheduling) is around past 51-ish measures, which is not too bad I think overall (also given ~148 bpm). unfortunately the current strategy doesn't appear to be infinitely scalable 😅 (for both playback and visualization). see my attached file to test and see (it's an arrangement of the OP, 「旅しよ！don't you？」from the anime [『ざつ旅-That's Journey-』)
[「旅しよ！don't you？」.json](https://github.com/user-attachments/files/21082864/don.t.you.json)
