### PR TITLE
readme update + 3d visualizer adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ also influenced a bit by PxTone Collage, another great application!
 - each note is customizable    
 - togglable onion skin    
 - recordable    
+- can select and move multiple notes at once    
 - can export project as an .mmp file for use in LMMS    
-- has a couple visualizers (although may be a bit buggy atm and doesn't seem to work for any projects that have more than 51 measures)    
+- has visualizers (although may be a bit buggy atm and may not work for any projects that have more than 51 measures)    
 ![visualizer](screenshots/visualizer.gif "visualizer")    
     
 ### instructions:    
@@ -50,8 +51,7 @@ I've also implemented a rudimentary custom instrument preset import ability (use
 Disclaimer: the custom instrument functionality is currently pretty limited; there are lots of possible custom preset configurations that will break under my current implementation. So this feature is definitely a work-in-progress but you can maybe at least see its future potential! :)    
     
 ### current issues/limitations:        
-- (Chrome) downloading the audio isn't great - the audio comes out fine but the duration is messed up (see: https://stackoverflow.com/questions/38443084/how-can-i-add-predefined-length-to-audio-recorded-from-mediarecorder-in-chrome).    
-- visualization doesn't work for projects that are more than 51 measures long
+- some visualizations may not work well for projects that are more than 51 measures long (due to limitations in canvas size as I'm stretching a canvas over the piano roll for some of the visualizations)    
 - projects longer than 51 measures may experience some lag with some notes on playback (probably due to the way I'm scheduling notes for playback)
     
 ### current next steps?:    

--- a/src/classes.js
+++ b/src/classes.js
@@ -210,13 +210,9 @@ function PianoRoll(){
     this.recorder.onstop = (function(pianoRoll){
       return function(evt){
         const blob = new Blob(pianoRoll.audioDataChunks, {'type': 'audio/ogg; codecs=opus'});
-        console.log(blob);
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-                
-        // duration for output file will be set to infinity on Chrome
-        // I don't think I can edit the file's duration unless you do some crazy annoying stuff. it's a chrome bug :/
 
         // note this is specific to my page html
         link.download = document.getElementById('pieceTitle').textContent + "_pianorollfun";

--- a/src/domModification.js
+++ b/src/domModification.js
@@ -571,6 +571,17 @@ const onendFunc = function(colHeaderId, lastColId, pianoRollObject){
           behavior: "smooth",
         });
       }
+      
+      // change the currently playing note to wireframe when using the 3d visualizer
+      // TODO: this isn't great atm but does provide some visual indication (albeit a bit inaccurate) about where things are
+      if(pianoRollObject.selectedVisualizer === '3d' && pianoRollObject.visualizer3dScene){
+        for(let child of pianoRollObject.visualizer3dScene.children){
+          if(child.name.includes(colHeaderId)){
+            child.material.wireframe = true;
+            break;
+          }
+        }
+      }
     }
 
     pianoRollObject.lastNoteColumn = currCol;

--- a/src/domModification.js
+++ b/src/domModification.js
@@ -575,7 +575,7 @@ const onendFunc = function(colHeaderId, lastColId, pianoRollObject){
       // change the currently playing note to wireframe when using the 3d visualizer
       // TODO: this isn't great atm but does provide some visual indication (albeit a bit inaccurate) about where things are
       if(pianoRollObject.selectedVisualizer === '3d' && pianoRollObject.visualizer3dScene){
-        for(let child of pianoRollObject.visualizer3dScene.children){
+        for(const child of pianoRollObject.visualizer3dScene.children){
           if(child.name.includes(colHeaderId)){
             child.material.wireframe = true;
             break;

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,11 +50,10 @@ function bindButtons(pianoRollObject){
     context.resume().then(() => {
       if(pianoRoll.selectedVisualizer){
         if(pianoRoll.selectedVisualizer === '3d'){
-          // TODO: just do current instrument
           if(pianoRoll.visualizerCanvas3d && pianoRoll.visualizerRequestAnimationFrameId3d === null){
             visualizer3dAnimationLoop(pianoRoll);
           }else{
-            buildVisualizer3D('grid', pianoRoll);
+            buildVisualizer3D('grid', pianoRoll, false); // show only current instrument's notes
           }
         }else{
           buildVisualizer('grid', pianoRoll);

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -134,7 +134,7 @@ function removeVisualizer3d(pianoRollObject){
   }
 }
 
-function buildVisualizer3D(gridDivId, pianoRollObject){
+function buildVisualizer3D(gridDivId, pianoRollObject, allInstruments=true){
   // remove existing visualizer first
   removeVisualizer3d(pianoRollObject);
   
@@ -181,13 +181,13 @@ function buildVisualizer3D(gridDivId, pianoRollObject){
   pianoRollObject.visualizerCanvas3d = canvasContainer;
   pianoRollObject.visualizer3dRenderer = renderer;
   
-  populateVisualizer3dScene(pianoRollObject, scene);
+  populateVisualizer3dScene(pianoRollObject, scene, allInstruments);
   
   // render the scene and launch animation loop
   visualizer3dAnimationLoop(pianoRollObject);
 }
 
-function populateVisualizer3dScene(pianoRollObject, scene){
+function populateVisualizer3dScene(pianoRollObject, scene, allInstruments){
   // data should be instruments, e.g.
   /* 
     pianoRoll.instruments = [
@@ -240,7 +240,13 @@ function populateVisualizer3dScene(pianoRollObject, scene){
   }
   
   let startZ = 0;
-  pianoRoll.instruments.forEach(inst => {
+  
+  let instruments = pianoRoll.instruments;
+  if(!allInstruments){
+    instruments = [pianoRoll.currentInstrument];
+  }
+  
+  instruments.forEach(inst => {
     const startX = getLeftmostScreenEdgeIn3dSpace(pianoRollObject) + 1; // +1 for a little buffer room
     const noteColor = inst.noteColorStart;
     inst.notes.forEach(noteGroup => {
@@ -255,6 +261,7 @@ function populateVisualizer3dScene(pianoRollObject, scene){
         
         const newNote = createNote(length, height, depth, noteColor);
         newNote.type = 'note';
+        newNote.name = document.getElementById(note.block.id).parentNode.id;
         scene.add(newNote);
         
         newNote.position.set(xPos, yPos, zPos);


### PR DESCRIPTION
This PR:
- updates the readme
  - it looks like the duration issue with `MediaRecorder` output has been fixed now for chrome :D (at least for my purposes from what I can tell - see https://issues.chromium.org/issues/40482588), which means the recorded output .ogg files now have a duration set (and is not infinity like before)

<br />

- makes it so that playing just the currently selected instrument is properly reflected in 3d visualizer
> <img width="1372" height="942" alt="15-08-2026_210446" src="https://github.com/user-attachments/assets/73f8e44b-03a0-4661-9617-c542302ee336" />

<br />

- adds transition to wireframe material for 3d visualizer notes when those notes should be done playing to give some visual indication of where things are
  - the implementation of this depends on the column-highlighting via specific oscillator nodes, which only tell us grid column header ids, because I don't have another way to know exactly what notes are playing at a given time (since notes are scheduled and there's not a single oscillator node for each note, although that would be helpful here but I think was the cause of performance issues and what led me to use a strategy to find the minimum number of nodes needed per instrument), so it's just an approximation
  - kinda buggy - some notes way ahead of the playback get changed to wireframe but that may be an indication of a bug maybe(?) with how I'm doing the column highlighting)
  
 
> <img width="1530" height="979" alt="15-08-2026_203405" src="https://github.com/user-attachments/assets/3515877b-ca53-433a-80c4-6a9f4acba938" />

> <img width="822" height="378" alt="15-08-2026_203441" src="https://github.com/user-attachments/assets/33f618bf-9d3c-4f05-b2d8-364e3122aaf0" />
